### PR TITLE
7903798: apidiff: Fix .jcheck/conf setting for tags

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -7,7 +7,7 @@ jbs=CODETOOLS
 error=author,committer,reviewers,merge,issues,executable,symlink,message,whitespace
 
 [repository]
-tags=apidiff(?:4\.1-b[0-9]{2}|5\.[01]-b[0-9]{2}|6|-[6789](?:\.[0-9]+)*\+[0-9]+)
+tags=(?:apidiff-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))
 branches=
 
 [census]


### PR DESCRIPTION
Please review a change to align apidiff tags with jdk tags

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903798](https://bugs.openjdk.org/browse/CODETOOLS-7903798): apidiff: Fix .jcheck/conf setting for tags (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.org/apidiff.git pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/1.diff">https://git.openjdk.org/apidiff/pull/1.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/1#issuecomment-2302957335)