### PR TITLE
7903800: apidiff: fix test docs and Makefile

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -53,7 +53,6 @@ clean:
 sanity:
 	@echo "JDKHOME               = $(JDKHOME)"
 	@echo "JUNIT_JAR             = $(JUNIT_JAR)"
-	@echo "JCOMMANDER_JAR        = $(JCOMMANDER_JAR)"
 	@echo "JAVADIFFUTILS_JAR     = $(JAVADIFFUTILS_JAR)"
 	@echo "JAVADIFFUTILS_LICENSE = $(JAVADIFFUTILS_LICENSE)"
 	@echo "DAISYDIFF_JAR         = $(DAISYDIFF_JAR)"

--- a/make/README.md
+++ b/make/README.md
@@ -10,7 +10,7 @@ _apidiff_ has various external dependencies:
 * _JDK_: must be at least JDK 17
 * _Java Diff Utils_
 * _Daisy Diff_
-* _TestNG_ and _JCommander_ (for testing only)
+* _JUnit_ (for testing only)
 
 ## Using `make/build.sh`
 
@@ -34,7 +34,7 @@ The script supports the following build scenarios:
 
 * Use local copies of the dependencies on the same machine.
   The details can be specified in an alternate `version-numbers` file,
-  or you can bypas the script entirely and invoke `make` directly.
+  or you can bypass the script entirely and invoke `make` directly.
 
 For more details, see the comments in `make/build.sh` and use the `--help`
 option when running the script.
@@ -48,7 +48,7 @@ The makefile provides the following targets:
 
 * `test`: run tests
 
-    Requires `TESTNG_JAR` and `JCOMMANDER_JAR` to be set.
+    Requires `JUNIT_JAR` to be set.
 
 * `clean`: delete the `build` directory and its contents
 


### PR DESCRIPTION
Please review a trivial fix to address some "TestNG leftovers" from the change to use JUnit

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903800](https://bugs.openjdk.org/browse/CODETOOLS-7903800): apidiff: fix test docs and Makefile (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.org/apidiff.git pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/3.diff">https://git.openjdk.org/apidiff/pull/3.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/3#issuecomment-2305363860)