### PR TITLE
7903822: Add toString for some internal types

### DIFF
--- a/src/share/classes/jdk/codetools/apidiff/model/API.java
+++ b/src/share/classes/jdk/codetools/apidiff/model/API.java
@@ -358,6 +358,11 @@ public abstract class API {
                 this.locn = locn;
                 this.kinds = kinds;
             }
+
+            @Override
+            public String toString() {
+                return getClass().getSimpleName() + "[locn:" + locn + ",kinds:" + kinds + "]";
+            }
         }
 
         private Map<String, LocationAndKinds> moduleLocationAndKinds;

--- a/src/share/classes/jdk/codetools/apidiff/model/Selector.java
+++ b/src/share/classes/jdk/codetools/apidiff/model/Selector.java
@@ -178,6 +178,14 @@ public class Selector {
             return excludesPackage(moduleName, packageName)
                     || includesPackage(moduleName, packageName) && excludeType.test(typeName);
         }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "[modulePart:" + modulePart
+                    + ",packagePart:" + packagePart
+                    + ",typePart:" + typePart
+                    + "]";
+        }
     }
 
     final List<Entry> includes;


### PR DESCRIPTION
Please review a trivial update to add a useful definition of `.toString()` for some internal classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903822](https://bugs.openjdk.org/browse/CODETOOLS-7903822): Add toString for some internal types (**Enhancement** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/5/head:pull/5` \
`$ git checkout pull/5`

Update a local copy of the PR: \
`$ git checkout pull/5` \
`$ git pull https://git.openjdk.org/apidiff.git pull/5/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 5`

View PR using the GUI difftool: \
`$ git pr show -t 5`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/5.diff">https://git.openjdk.org/apidiff/pull/5.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/5#issuecomment-2359276385)