### PR TITLE
7903823: Use correct key when building display of method return types

### DIFF
--- a/src/share/classes/jdk/codetools/apidiff/report/html/TypePageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/TypePageReporter.java
@@ -577,7 +577,7 @@ class TypePageReporter extends PageReporter<TypeElementKey> {
                     contents.add(Text.of(pageKey.name.toString()));
 
                 case METHOD -> {
-                    contents.add(buildType(ePos,
+                    contents.add(buildType(ePos.returnType(),
                             ((ExecutableElement) e)::getReturnType));
                     contents.add(Text.SPACE);
                     contents.add(Text.of(e.getSimpleName()));


### PR DESCRIPTION
Please review a simple fix to use the correct position-key to identify the different return types of a method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903823](https://bugs.openjdk.org/browse/CODETOOLS-7903823): Use correct key when building display of method return types (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.org/apidiff.git pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/6.diff">https://git.openjdk.org/apidiff/pull/6.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/6#issuecomment-2359365880)