### PR TITLE
CODETOOLS-7903834: apidiff: DocPath issue on Windows

### DIFF
--- a/src/share/classes/jdk/codetools/apidiff/report/html/DocPath.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/DocPath.java
@@ -59,6 +59,7 @@ public class DocPath {
      * @param p the string
      */
     protected DocPath(String p) {
+        p = p.replace(File.separatorChar, '/'); // normalize paths
         path = (p.endsWith("/") ? p.substring(0, p.length() - 1) : p);
     }
 


### PR DESCRIPTION
Please review a small fix to correctly handle Windows paths.