### PR TITLE
ODETOOLS-7903835: apidiff: CompareOptionsTest fails on recent JDK

### DIFF
--- a/test/junit/apitest/CompareOptionsTest.java
+++ b/test/junit/apitest/CompareOptionsTest.java
@@ -55,10 +55,10 @@ public class CompareOptionsTest extends APITester {
         Path outDir = run(base, "--compare-api-descriptions-as-text=true");
         checkOutput(outDir.resolve("p/C.html"),
                 """
-                      7 <span class="sdiffs-lines-changed"> abc. </span><span class="sdiffs-chars-changed">BEFORE</span><span class="sdiffs-lines-changed">. def.</span>
+                    <span class="sdiffs-lines-changed"> abc. </span><span class="sdiffs-chars-changed">BEFORE</span><span class="sdiffs-lines-changed">. def.</span>
                     """,
                 """
-                      7 <span class="sdiffs-lines-changed"> abc. </span><span class="sdiffs-chars-changed">AFTER</span><span class="sdiffs-lines-changed">. def.</span>
+                    <span class="sdiffs-lines-changed"> abc. </span><span class="sdiffs-chars-changed">AFTER</span><span class="sdiffs-lines-changed">. def.</span>
                     """);
     }
 


### PR DESCRIPTION
Please review a simple fix to not include line numbers in the reference output for this test. The underlying javadoc output has changed, so the line numbers in the diff have also changed.