### PR TITLE
7903837: apidiff: build.sh issues on Windows

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -52,13 +52,16 @@ clean:
 
 sanity:
 	@echo "JDKHOME               = $(JDKHOME)"
-	@echo "JUNIT_JAR             = $(JUNIT_JAR)"
-	@echo "JAVADIFFUTILS_JAR     = $(JAVADIFFUTILS_JAR)"
-	@echo "JAVADIFFUTILS_LICENSE = $(JAVADIFFUTILS_LICENSE)"
 	@echo "DAISYDIFF_JAR         = $(DAISYDIFF_JAR)"
+	@echo "DAISYDIFF_SRC         = $(DAISYDIFF_SRC)"
 	@echo "DAISYDIFF_LICENSE     = $(DAISYDIFF_LICENSE)"
+	@echo "EQUINOX_JAR           = $(EQUINOX_JAR)"
+	@echo "EQUINOX_LICENSE       = $(EQUINOX_LICENSE)"
 	@echo "HTMLCLEANER_JAR       = $(HTMLCLEANER_JAR)"
 	@echo "HTMLCLEANER_LICENSE   = $(HTMLCLEANER_LICENSE)"
+	@echo "JAVADIFFUTILS_JAR     = $(JAVADIFFUTILS_JAR)"
+	@echo "JAVADIFFUTILS_LICENSE = $(JAVADIFFUTILS_LICENSE)"
+	@echo "JUNIT_JAR             = $(JUNIT_JAR)"
 
 check-build-vars:
 	@if [ -z "$(JDKHOME)" ]; then \
@@ -69,6 +72,12 @@ check-build-vars:
 	fi
 	@if [ -z "$(DAISYDIFF_LICENSE)" ]; then \
 		echo "DAISYDIFF_LICENSE not set (will not be included)" ; \
+	fi
+	@if [ -z "$(EQUINOX_JAR)" ]; then \
+		echo "EQUINOX_JAR not set" ; exit 1 ; \
+	fi
+	@if [ -z "$(EQUINOX_LICENSE)" ]; then \
+		echo "EQUINOX_LICENSE not set (will not be included)" ; \
 	fi
 	@if [ -z "$(HTMLCLEANER_JAR)" ]; then \
 		echo "HTMLCLEANER_JAR not set" ; exit 1 ; \

--- a/make/apidiff.gmk
+++ b/make/apidiff.gmk
@@ -33,11 +33,14 @@ JAVAFILES.jdk.codetools.apidiff := \
 ifneq ($(DAISYDIFF_SRC),)
 	DAISYDIFF_SRC_JAVA = $(DAISYDIFF_SRC)/main/java
 	DAISYDIFF_SRC_RESOURCES = $(DAISYDIFF_SRC)/main/resources
+	DAISYDIFF_CLASSPATH_ELEMENT = $(DAISYDIFF_SRC_JAVA)
+else
+	DAISYDIFF_CLASSPATH_ELEMENT = $(DAISYDIFF_JAR)
 endif
 
 $(BUILDDIR)/classes.jdk.codetools.apidiff.ok: $(JAVAFILES.jdk.codetools.apidiff)
 	$(JAVAC) $(JAVAC_OPTIONS) \
-		-cp $(JAVADIFFUTILS_JAR):$(DAISYDIFF_JAR):$(DAISYDIFF_SRC_JAVA):$(EQUINOX_JAR):$(HTMLCLEANER_JAR) \
+		-cp $(JAVADIFFUTILS_JAR):$(DAISYDIFF_CLASSPATH_ELEMENT):$(EQUINOX_JAR):$(HTMLCLEANER_JAR) \
 		-d $(CLASSDIR) \
 		$(JAVAFILES.jdk.codetools.apidiff)
 	echo "classes built at `date`" > $@

--- a/make/build-support/build-common.sh
+++ b/make/build-support/build-common.sh
@@ -280,7 +280,8 @@ if [ -z "${log_module:-}" ]; then
     exit 1
 fi
 
-ROOT="$(abspath ${ROOT:-${mydir}/..})"
+DEFAULT_ROOT="$(builtin cd ${mydir}/..; pwd)"
+ROOT="$(abspath ${ROOT:-${DEFAULT_ROOT}})"
 BUILD_DIR="$(abspath "${BUILD_DIR:-${ROOT}/build}")"
 DEPS_DIR="${BUILD_DIR}/deps"
 

--- a/make/build.sh
+++ b/make/build.sh
@@ -665,22 +665,22 @@ cat > ${BUILD_DIR}/make.sh << EOF
 
 # Build apidiff
 cd "${ROOT}/make"
-make BUILDDIR="${BUILD_DIR}"                                  \\
-     BUILD_MILESTONE="${APIDIFF_BUILD_MILESTONE}"             \\
-     BUILD_NUMBER="${APIDIFF_BUILD_NUMBER}"                   \\
-     BUILD_VERSION="${APIDIFF_VERSION}"                       \\
-     BUILD_VERSION_STRING="${APIDIFF_VERSION_STRING}"         \\
-     DAISYDIFF_JAR="$(mixed_path "${DAISYDIFF_JAR:-}")"       \\
-     DAISYDIFF_SRC="$(mixed_path "${DAISYDIFF_SRC:-}")"       \\
-     DAISYDIFF_LICENSE="${DAISYDIFF_LICENSE}"                 \\
-     EQUINOX_JAR="$(mixed_path "${EQUINOX_JAR:-}")"           \\
-     EQUINOX_LICENSE="$(mixed_path "${EQUINOX_LICENSE:-}")"   \\
-     HTMLCLEANER_JAR="${HTMLCLEANER_JAR}"                     \\
-     HTMLCLEANER_LICENSE="${HTMLCLEANER_LICENSE}"             \\
-     JAVADIFFUTILS_JAR="$(mixed_path "${JAVADIFFUTILS_JAR}")" \\
-     JAVADIFFUTILS_LICENSE="${JAVADIFFUTILS_LICENSE}"         \\
-     JDKHOME="${JAVA_HOME}"                                   \\
-     JUNIT_JAR="$(mixed_path "${JUNIT_JAR}")"                 \\
+make BUILDDIR="${BUILD_DIR}"                                            \\
+     BUILD_MILESTONE="${APIDIFF_BUILD_MILESTONE}"                       \\
+     BUILD_NUMBER="${APIDIFF_BUILD_NUMBER}"                             \\
+     BUILD_VERSION="${APIDIFF_VERSION}"                                 \\
+     BUILD_VERSION_STRING="${APIDIFF_VERSION_STRING}"                   \\
+     DAISYDIFF_JAR="$(mixed_path "${DAISYDIFF_JAR:-}")"                 \\
+     DAISYDIFF_SRC="$(mixed_path "${DAISYDIFF_SRC:-}")"                 \\
+     DAISYDIFF_LICENSE="$(mixed_path "${DAISYDIFF_LICENSE:-}")"         \\
+     EQUINOX_JAR="$(mixed_path "${EQUINOX_JAR:-}")"                     \\
+     EQUINOX_LICENSE="$(mixed_path "${EQUINOX_LICENSE:-}")"             \\
+     HTMLCLEANER_JAR="$(mixed_path "${HTMLCLEANER_JAR:-}")"             \\
+     HTMLCLEANER_LICENSE="$(mixed_path "${HTMLCLEANER_LICENSE:-}")"     \\
+     JAVADIFFUTILS_JAR="$(mixed_path "${JAVADIFFUTILS_JAR}")"           \\
+     JAVADIFFUTILS_LICENSE="$(mixed_path "${JAVADIFFUTILS_LICENSE}")"   \\
+     JDKHOME="$(mixed_path ${JAVA_HOME})"                               \\
+     JUNIT_JAR="$(mixed_path "${JUNIT_JAR}")"                           \\
    "\$@"
 EOF
 

--- a/test/junit/JUnitTests.gmk
+++ b/test/junit/JUnitTests.gmk
@@ -30,7 +30,7 @@ JUnitTest.add-exports =  \
 		--add-exports jdk.jdeps/com.sun.tools.classfile=ALL-UNNAMED
 
 JUnitTest.classpath = \
-		$(BUILDTESTDIR)/JUnitTests/classes:$(APIDIFF_IMAGEDIR)/lib/apidiff.jar:$(JAVADIFFUTILS_JAR):$(HTMLCLEANER_JAR)
+		$(BUILDTESTDIR)/JUnitTests/classes:$(APIDIFF_IMAGEDIR)/lib/apidiff.jar:$(JAVADIFFUTILS_JAR):$(HTMLCLEANER_JAR):$(EQUINOX_JAR)
 
 ifneq ($(DAISYDIFF_JAR),)
 		JUnitTest.classpath += :$(DAISYDIFF_JAR)

--- a/test/junit/JUnitTests.gmk
+++ b/test/junit/JUnitTests.gmk
@@ -30,7 +30,11 @@ JUnitTest.add-exports =  \
 		--add-exports jdk.jdeps/com.sun.tools.classfile=ALL-UNNAMED
 
 JUnitTest.classpath = \
-		$(BUILDTESTDIR)/JUnitTests/classes:$(APIDIFF_IMAGEDIR)/lib/apidiff.jar:$(JAVADIFFUTILS_JAR):$(DAISYDIFF_JAR):$(HTMLCLEANER_JAR)
+		$(BUILDTESTDIR)/JUnitTests/classes:$(APIDIFF_IMAGEDIR)/lib/apidiff.jar:$(JAVADIFFUTILS_JAR):$(HTMLCLEANER_JAR)
+
+ifneq ($(DAISYDIFF_JAR),)
+		JUnitTest.classpath += :$(DAISYDIFF_JAR)
+endif
 
 $(BUILDTESTDIR)/JUnitTests.ok: \
 		$(BUILDTESTDIR)/JUnitTests.classes.ok


### PR DESCRIPTION
Please review some `build.sh` and `Makefile` changes to address issues building on Windows.

The primary Windows issue was missing use of `mixed_path` when passing some filenames into `make`.
There is some additional cleanup (for all platforms) to normalize the `DEPS_DIR` and add missing items to the `sanity` and `check_build_vars` targets.

This has been tested on macOS. Can someone with access to a Windows machine test it on Windows, please?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903837](https://bugs.openjdk.org/browse/CODETOOLS-7903837): apidiff: build.sh issues on Windows (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/apidiff.git pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/12.diff">https://git.openjdk.org/apidiff/pull/12.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/12#issuecomment-2374794072)