### PR TITLE
7903838: apidiff: Update Vintage JUnit test

### DIFF
--- a/test/junit/apitest/SerializationMethodsTest.java
+++ b/test/junit/apitest/SerializationMethodsTest.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
 
 import jdk.codetools.apidiff.Main;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;


### PR DESCRIPTION
Please review a trivial fix to upgrade a test to use the recommended `@Test` annotation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903838](https://bugs.openjdk.org/browse/CODETOOLS-7903838): apidiff: Update Vintage JUnit test (**Enhancement** - P3)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/apidiff.git pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/13.diff">https://git.openjdk.org/apidiff/pull/13.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/13#issuecomment-2375149275)