### PR TITLE
7903839: apidiff: Add a "make docs" target for the primary internal API

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -41,6 +41,8 @@ build: check-build-vars $(BUILDFILES)
 
 images: $(VERBOSEZIPFILES)
 
+docs: $(BUILDDIR)/api.jdk.codetools.apidiff.ok
+
 test: check-test-vars $(INITIAL_TESTS) $(TESTS) $(FINAL_TESTS)
 	count=`echo $+ | wc -w` ; \
 	echo "All ($${count}) selected tests completed successfully"

--- a/make/apidiff.gmk
+++ b/make/apidiff.gmk
@@ -307,10 +307,10 @@ $(BUILDDIR)/api.jdk.codetools.apidiff.ok: \
 	$(JAVADOC) $(JAVADOC_OPTIONS) \
 		-Xdoclint:-missing \
 		-quiet \
-		-cp $(JAVADIFFUTILS_JAR):$(DAISYDIFF_JAR) \
+		-cp $(JAVADIFFUTILS_JAR):$(DAISYDIFF_JAR):$(DAISYDIFF_SRC_JAVA):$(EQUINOX_JAR):$(HTMLCLEANER_JAR) \
 		-overview $(SRCDOCDIR)/overview.html \
 		-linkoffline \
-		    https://docs.oracle.com/en/java/javase/11/docs/api/index.html \
+		    https://docs.oracle.com/en/java/javase/17/docs/api/index.html \
 		    $(SRCDOCDIR)/jdk17.api \
 		-d $(BUILDDIR)/api \
 		$(JAVAFILES.jdk.codetools.apidiff)


### PR DESCRIPTION
Please review a small Makefile update to expose a friendly "make docs" target to generate API documentation for the internal API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903839](https://bugs.openjdk.org/browse/CODETOOLS-7903839): apidiff: Add a "make docs" target for the primary internal API (**Enhancement** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/apidiff.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/14.diff">https://git.openjdk.org/apidiff/pull/14.diff</a>

</details>
