### PR TITLE
7903841: apidiff: IllegalStateException for RECORD in TypePageReporter

### DIFF
--- a/src/share/classes/jdk/codetools/apidiff/report/html/TypePageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/TypePageReporter.java
@@ -223,8 +223,10 @@ class TypePageReporter extends PageReporter<TypeElementKey> {
         Set<Content> keywords = tMap.values().stream()
                 .map(e -> {
                     return switch (e.getKind()) {
-                        case CLASS, ENUM -> Keywords.IMPLEMENTS;
+                        case CLASS, ENUM, RECORD -> Keywords.IMPLEMENTS;
                         case ANNOTATION_TYPE, INTERFACE -> Keywords.EXTENDS;
+                        // for newer kinds, not supported by the default version of JDK
+                        // used to compile apidiff, use a reflective comparison
                         default -> throw new IllegalStateException((e.getKind().toString()));
                     };
                 })


### PR DESCRIPTION
Please review a trivial fix to include RECORD in the set of known element kinds for classes and interfaces

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903841](https://bugs.openjdk.org/browse/CODETOOLS-7903841): apidiff: IllegalStateException for RECORD in TypePageReporter (**Bug** - P2)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.org/apidiff.git pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/15.diff">https://git.openjdk.org/apidiff/pull/15.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/15#issuecomment-2375397820)