### PR TITLE
7903846: apidiff: test issues on Windows

### DIFF
--- a/test/junit/JUnitTests.gmk
+++ b/test/junit/JUnitTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ JUnitTest.add-exports =  \
 		--add-exports jdk.jdeps/com.sun.tools.classfile=ALL-UNNAMED
 
 JUnitTest.classpath = \
-		$(BUILDTESTDIR)/JUnitTests/classes:$(APIDIFF_IMAGEDIR)/lib/apidiff.jar:$(JAVADIFFUTILS_JAR):$(DAISYDIFF_JAR):$(HTMLCLEANER_JAR):$(EQUINOX_JAR)
+		$(BUILDTESTDIR)/JUnitTests/classes:$(APIDIFF_IMAGEDIR)/lib/apidiff.jar:$(JAVADIFFUTILS_JAR):$(DAISYDIFF_JAR):$(HTMLCLEANER_JAR)
 
 $(BUILDTESTDIR)/JUnitTests.ok: \
 		$(BUILDTESTDIR)/JUnitTests.classes.ok

--- a/test/junit/JUnitTests.gmk
+++ b/test/junit/JUnitTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ JUnitTest.add-exports =  \
 		--add-exports jdk.jdeps/com.sun.tools.classfile=ALL-UNNAMED
 
 JUnitTest.classpath = \
-		$(BUILDTESTDIR)/JUnitTests/classes:$(APIDIFF_IMAGEDIR)/lib/apidiff.jar:$(JAVADIFFUTILS_JAR):$(DAISYDIFF_JAR):$(HTMLCLEANER_JAR)
+		$(BUILDTESTDIR)/JUnitTests/classes:$(APIDIFF_IMAGEDIR)/lib/apidiff.jar:$(JAVADIFFUTILS_JAR):$(DAISYDIFF_JAR):$(HTMLCLEANER_JAR):$(EQUINOX_JAR)
 
 $(BUILDTESTDIR)/JUnitTests.ok: \
 		$(BUILDTESTDIR)/JUnitTests.classes.ok


### PR DESCRIPTION
Please review a fix for some issues reported when running tests on Windows.

For `GetSerialVersionUITest`, the derivation of the working directory was broken in a couple of ways, which have both been fixed:
1. the computation of the path name assumed all members were fields; whereas the test cases have evolved to include other complex members
2. the work/scratch directory was being emptied between test cases, so that only the last one remained. there is a more appropriate method to use instead, so that all the working files are preserved

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903846](https://bugs.openjdk.org/browse/CODETOOLS-7903846): apidiff: test issues on Windows (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer) ⚠️ Review applies to [616a1d77](https://git.openjdk.org/apidiff/pull/16/files/616a1d77f1f1e87802a0c8fc5fa8a31c5197cf08)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.org/apidiff.git pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/16.diff">https://git.openjdk.org/apidiff/pull/16.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/16#issuecomment-2377716240)