### PR TITLE
7903830: apidiff: Review glyphs used to indicate same/difference

### DIFF
--- a/src/share/classes/jdk/codetools/apidiff/Main.java
+++ b/src/share/classes/jdk/codetools/apidiff/Main.java
@@ -170,6 +170,8 @@ public class Main {
         Selector s = new Selector(options.includes, options.excludes);
         AccessKind ak = options.getAccessKind();
 
+        // TODO: when APIDiff moves to JDK 21, thia can trivially become SequencedSet,
+        //       which would be useful in varoius places, such as PageReporter.getResultGlyph
         Set<API> apis = options.allAPIOptions.values().stream()
                 .map(a -> API.of(a, s, ak, log))
                 .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/src/share/classes/jdk/codetools/apidiff/html/Entity.java
+++ b/src/share/classes/jdk/codetools/apidiff/html/Entity.java
@@ -45,10 +45,14 @@ public class Entity extends Content {
     public static final Entity CROSS = new Entity("cross", 0x2717);
     /** Unicode EQUALS SIGN. */
     public static final Entity EQUALS = new Entity("equals", 0x3d);
-    /** Unicode NOT EQUAL TO. */
-    public static final Entity NE = new Entity("ne", 0x2260);
+    /** Unicode MINUS. */
+    public static final Entity MINUS = new Entity("minus", 0x2212);
     /** Unicode NO-BREAK SPACE. */
     public static final Entity NBSP = new Entity("nbsp", 0xa0);
+    /** Unicode NOT EQUAL TO. */
+    public static final Entity NE = new Entity("ne", 0x2260);
+    /** Unicode PLUS. */
+    public static final Entity PLUS = new Entity("plus", 0x2b);
 
     private static final boolean useNumericEntities = Boolean.getBoolean("useNumericEntities");
 

--- a/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
@@ -179,7 +179,7 @@ div.signature {
 
 .doc-files span.diff,   .element span.diff,   .enclosed span.diff,   .serial-form span.diff,
 .doc-files span.same,   .element span.same,   .enclosed span.same,   .serial-form span.same,
-.doc-files span.single, .element span.single, .enclosed span.single, .serial-form span.single {
+.doc-files span.partial, .element span.partial, .enclosed span.partial, .serial-form span.partial {
     display: inline-block;
     width: 2em;
     margin-right: 0.5ex;
@@ -197,7 +197,7 @@ div.signature {
     color: #080;
 }
 
-.doc-files span.single, .element span.single, .enclosed span.single, .serial-form span.single {
+.doc-files span.partial, .element span.partial, .enclosed span.partial, .serial-form span.partial {
     background: #ddf;
     color: #008;
 }


### PR DESCRIPTION
Please review a medium small fix to change the glyphs used to visually indicate whether elements are the same, different, or in the case of a two-way comparison, added or removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903830](https://bugs.openjdk.org/browse/CODETOOLS-7903830): apidiff: Review glyphs used to indicate same/difference (**Enhancement** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/apidiff.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/17.diff">https://git.openjdk.org/apidiff/pull/17.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/17#issuecomment-2380109004)