### PR TITLE
7903852: apidiff: IllegalArgumentException for RECORD_COMPONENT

### DIFF
--- a/src/share/classes/jdk/codetools/apidiff/model/API.java
+++ b/src/share/classes/jdk/codetools/apidiff/model/API.java
@@ -58,6 +58,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
@@ -966,7 +967,16 @@ public abstract class API {
             }
 
             @Override
+            public String visitRecordComponent(RecordComponentElement tpe, APIDocs d) {
+                // record components do not have distinct API descriptions of their own:
+                // they are documented by @param tags in the enclosing element
+                throw new IllegalArgumentException(tpe.getKind() + " " + tpe.getSimpleName());
+            }
+
+            @Override
             public String visitTypeParameter(TypeParameterElement tpe, APIDocs d) {
+                // type parameters do not have distinct API descriptions of their own:
+                // they are documented by @param tags in the enclosing element
                 throw new IllegalArgumentException(tpe.getKind() + " " + tpe.getSimpleName());
             }
 

--- a/src/share/classes/jdk/codetools/apidiff/model/RecordComponentComparator.java
+++ b/src/share/classes/jdk/codetools/apidiff/model/RecordComponentComparator.java
@@ -70,8 +70,8 @@ public class RecordComponentComparator extends ElementComparator<Element> {
             allEqual = checkMissing(rcPos, rcMap);
             if (rcMap.size() > 1) {
                 allEqual &= compareSignatures(rcPos, rcMap);
-                allEqual &= compareDocComments(rcPos, rcMap);
-                allEqual &= compareApiDescriptions(rcPos, rcMap);
+                // note that record components do not have distinct API descriptions or doc comments
+                // of their own; they are documented by @param tags in the enclosing element
             }
         } finally {
             reporter.completed(rcPos, allEqual);

--- a/src/share/classes/jdk/codetools/apidiff/model/TypeParameterComparator.java
+++ b/src/share/classes/jdk/codetools/apidiff/model/TypeParameterComparator.java
@@ -89,6 +89,9 @@ public class TypeParameterComparator extends ElementComparator<TypeParameterElem
         allEquals &= compareNames(pos, map)
                 & compareBounds(pos, map)
                 & new AnnotationComparator(map.keySet(), accessKind, reporter).compareAll(pos, map);
+        // note that type parameters do not have distinct API descriptions or doc comments
+        // of their own; they are documented by @param tags in the enclosing element
+
 
         return allEquals;
     }


### PR DESCRIPTION
Please review a small fix for an IllegalArgumentException.

The exception is "correct"; the error is at the call site which should not be calling the method that throws the exception.
Record components, like type parameters, do not have distinct A:PI descriptions that can be compared.

Separately, we need better back-end tests for `HtmlReporter`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903852](https://bugs.openjdk.org/browse/CODETOOLS-7903852): apidiff: IllegalArgumentException for RECORD_COMPONENT (**Bug** - P2)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - no project role)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/apidiff.git pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/20.diff">https://git.openjdk.org/apidiff/pull/20.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/20#issuecomment-2386594182)