### PR TITLE
7903851: apidiff: typo in comment for HtmlDiffBuilderTest

### DIFF
--- a/test/junit/apitest/HtmlDiffBuilderTest.java
+++ b/test/junit/apitest/HtmlDiffBuilderTest.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.Test;
 import apitest.lib.APITester;
 
 /**
- * Unit tests for the {@code TextDiffBuilder} class.
+ * Unit tests for the {@code HtmlDiffBuilder} class.
  */
 public class HtmlDiffBuilderTest extends APITester {
     /**


### PR DESCRIPTION
Please review a fix for a trivial typo in a comment in a test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903851](https://bugs.openjdk.org/browse/CODETOOLS-7903851): apidiff: typo in comment for HtmlDiffBuilderTest (**Bug** - P5)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - no project role)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/apidiff.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/21.diff">https://git.openjdk.org/apidiff/pull/21.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/21#issuecomment-2386600916)