### PR TITLE
7903856: apidiff: 7903837 breaks some builds

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ check-build-vars:
 		echo "DAISYDIFF_LICENSE not set (will not be included)" ; \
 	fi
 	@if [ -z "$(EQUINOX_JAR)" ]; then \
-		echo "EQUINOX_JAR not set" ; exit 1 ; \
+		echo "EQUINOX_JAR not set (will not be included)" ; \
 	fi
 	@if [ -z "$(EQUINOX_LICENSE)" ]; then \
 		echo "EQUINOX_LICENSE not set (will not be included)" ; \

--- a/make/apidiff.gmk
+++ b/make/apidiff.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 1999, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,14 @@ else
 	DAISYDIFF_CLASSPATH_ELEMENT = $(DAISYDIFF_JAR)
 endif
 
+# include EQUINOX_JAR with DAISYDIFF if it is set
+ifneq ($(EQUINOX_JAR),)
+	DAISYDIFF_CLASSPATH_ELEMENT := $(DAISYDIFF_CLASSPATH_ELEMENT):$(EQUINOX_JAR)
+endif
+
 $(BUILDDIR)/classes.jdk.codetools.apidiff.ok: $(JAVAFILES.jdk.codetools.apidiff)
 	$(JAVAC) $(JAVAC_OPTIONS) \
-		-cp $(JAVADIFFUTILS_JAR):$(DAISYDIFF_CLASSPATH_ELEMENT):$(EQUINOX_JAR):$(HTMLCLEANER_JAR) \
+		-cp $(JAVADIFFUTILS_JAR):$(DAISYDIFF_CLASSPATH_ELEMENT):$(HTMLCLEANER_JAR) \
 		-d $(CLASSDIR) \
 		$(JAVAFILES.jdk.codetools.apidiff)
 	echo "classes built at `date`" > $@
@@ -310,7 +315,7 @@ $(BUILDDIR)/api.jdk.codetools.apidiff.ok: \
 	$(JAVADOC) $(JAVADOC_OPTIONS) \
 		-Xdoclint:-missing \
 		-quiet \
-		-cp $(JAVADIFFUTILS_JAR):$(DAISYDIFF_JAR):$(DAISYDIFF_SRC_JAVA):$(EQUINOX_JAR):$(HTMLCLEANER_JAR) \
+		-cp $(JAVADIFFUTILS_JAR):$(DAISYDIFF_CLASSPATH_ELEMENT):$(HTMLCLEANER_JAR) \
 		-overview $(SRCDOCDIR)/overview.html \
 		-linkoffline \
 		    https://docs.oracle.com/en/java/javase/17/docs/api/index.html \


### PR DESCRIPTION
Please review a small but important fix for an issue handling EQUINOX_JAR in some build environments.

The underlying issue is that EQUINOX_JAR may or may not be required, depending on the configuration for DAISYDIFF.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903856](https://bugs.openjdk.org/browse/CODETOOLS-7903856): apidiff: 7903837 breaks some builds (**Bug** - P2)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - no project role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.org/apidiff.git pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/22.diff">https://git.openjdk.org/apidiff/pull/22.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/22#issuecomment-2387569537)