### PR TITLE
7903857: Include test run in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Build and Test ApiDiff
+name: Build and Test APIDiff
 
 on:
   push:
@@ -14,17 +14,17 @@ jobs:
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
 
       - name: 'Set up Java Development Kit'
-        uses: oracle-actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          website: oracle.com
-          release: 17
+          distribution: 'oracle'
+          java-version: 17
 
-      - name: 'Build ApiDiff'
+      - name: 'Build APIDiff'
         shell: bash
-        run: |
-          java --version
-          bash make/build.sh
+        run: bash make/build.sh
+
+      - name: 'Self-test APIDiff'
+        shell: bash
+        run: bash make/build.sh --skip-download -- test

--- a/test/junit/JUnitTests.gmk
+++ b/test/junit/JUnitTests.gmk
@@ -41,7 +41,6 @@ $(BUILDTESTDIR)/JUnitTests.ok: \
 	$(RM) $(@:%.ok=%/work) $(@:%.ok=%/report)
 	$(MKDIR) -p $(@:%.ok=%/work) $(@:%.ok=%/report)
 	cd $(@:%.ok=%/work) ; \
-	set -o pipefail ; \
 	$(JAVA) \
 		$(JUnitTest.add-exports) \
 		-jar $(JUNIT_JAR) \


### PR DESCRIPTION
Please review this change to run APIDiff's self-tests for each pull request.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903857](https://bugs.openjdk.org/browse/CODETOOLS-7903857): Include test run in GitHub Actions workflow (**Enhancement** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - no project role)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/apidiff.git pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/25.diff">https://git.openjdk.org/apidiff/pull/25.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/25#issuecomment-2404681583)