### PR TITLE
7903866: apidiff: add an example to the doc

### DIFF
--- a/src/share/doc/apidiff.md
+++ b/src/share/doc/apidiff.md
@@ -503,10 +503,12 @@ The tool does _not_ attempt to run `javadoc` locally to generate the page on the
 To compare APIs in the `java.base` module in JDK builds `/local/baseline-jdk` and `/local/updated-jdk`, and place the result in the directory `out`, run the following command:
 
 ```
-bin/apidiff --api jdk \
-    --jdk-build=/local/baseline-jdk/build/linux-x86_64-server-fastdebug --jdk-docs docs \
+bin/apidiff
+    --api jdk \
+    --jdk-build /local/baseline-jdk/build/linux-x86_64-server-fastdebug
     --api sv \
-    --jdk-build=/local/updated-jdk/build/linux-x86_64-server-fastdebug --jdk-docs docs \
+    --jdk-build /local/updated-jdk/build/linux-x86_64-server-fastdebug
+    --jdk-docs docs \
     -d out \
     --compare-api-descriptions true \
     --include 'java.base/**'

--- a/src/share/doc/apidiff.md
+++ b/src/share/doc/apidiff.md
@@ -503,11 +503,11 @@ The tool does _not_ attempt to run `javadoc` locally to generate the page on the
 To compare APIs in the `java.base` module in JDK builds `/local/baseline-jdk` and `/local/updated-jdk`, and place the result in the directory `out`, run the following command:
 
 ```
-bin/apidiff
+bin/apidiff \
     --api jdk \
-    --jdk-build /local/baseline-jdk/build/linux-x86_64-server-fastdebug
+    --jdk-build /local/baseline-jdk/build/linux-x86_64-server-fastdebug \
     --api sv \
-    --jdk-build /local/updated-jdk/build/linux-x86_64-server-fastdebug
+    --jdk-build /local/updated-jdk/build/linux-x86_64-server-fastdebug \
     --jdk-docs docs \
     -d out \
     --compare-api-descriptions true \

--- a/src/share/doc/apidiff.md
+++ b/src/share/doc/apidiff.md
@@ -497,3 +497,18 @@ The tool does _not_ attempt to run `javadoc` locally to generate the page on the
 [jdk.compiler]: https://docs.oracle.com/en/java/javase/17/docs/api/jdk.compiler/module-summary.html
 [Java Language Model API]: https://docs.oracle.com/en/java/javase/17/docs/api/java.compiler/javax/lang/model/package-summary.html
 [Compiler Tree API]: https://docs.oracle.com/en/java/javase/17/docs/api/jdk.compiler/com/sun/source/doctree/package-summary.html
+
+## Example
+
+To compare APIs in the `java.base` module in JDK builds `/local/baseline-jdk` and `/local/updated-jdk`, and place the result in the directory `out`, run the following command:
+
+```
+bin/apidiff --api jdk \
+    --jdk-build=/local/baseline-jdk/build/linux-x86_64-server-fastdebug --jdk-docs docs \
+    --api sv \
+    --jdk-build=/local/updated-jdk/build/linux-x86_64-server-fastdebug --jdk-docs docs \
+    -d out \
+    --compare-api-descriptions true \
+    --include 'java.base/**'
+```
+


### PR DESCRIPTION
It's an example, for example. We need more.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7903866](https://bugs.openjdk.org/browse/CODETOOLS-7903866): apidiff: add an example to the doc (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/apidiff.git pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/26.diff">https://git.openjdk.org/apidiff/pull/26.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/26#issuecomment-2416919628)