### PR TITLE
7904080: APIDiff does not detect javadoc (and changes to javadoc) for methods with varargs

### DIFF
--- a/src/share/classes/jdk/codetools/apidiff/model/APIReader.java
+++ b/src/share/classes/jdk/codetools/apidiff/model/APIReader.java
@@ -325,7 +325,7 @@ public class APIReader extends HtmlParser {
                         blockDepth = 0;
                     }
                     debugPrintln(() -> "!! set id for TYPE member " + id);
-                    descriptionId = id;
+                    descriptionId = id.replace("...)", "[])");
                 }
                 break;
         }

--- a/test/junit/apitest/APIReaderTest.java
+++ b/test/junit/apitest/APIReaderTest.java
@@ -238,6 +238,14 @@ public class APIReaderTest extends APITester {
                              */
                             public void m2() { }
                             /**
+                             * This is first method with varagrs.
+                             */
+                            public void varargs1(Integer i, String... texts) { }
+                            /**
+                             * This is second method with varagrs.
+                             */
+                            public void varargs2(Integer i, int... texts) { }
+                            /**
                              * This is nested class N. This is more test for N.
                              * @see "See Text"
                              */
@@ -367,7 +375,7 @@ public class APIReaderTest extends APITester {
 
             case "C.html" -> {
                 checkDescription(docs.getDescription(), null, null, "This is class C. This is more");
-                checkMemberDescriptions(docs.getMemberDescriptions(), "<init>()", "<init>(int)", "f1", "f2", "m1()", "m2()");
+                checkMemberDescriptions(docs.getMemberDescriptions(), "<init>()", "<init>(int)", "f1", "f2", "m1()", "m2()", "varargs1(java.lang.Integer,java.lang.String[])", "varargs2(java.lang.Integer,int[])");
                 checkDescription(docs.getDescription("<init>()"),
                         "<init>()", "C", "This is the no-args constructor. This is more");
             }


### PR DESCRIPTION
The keys in the HTML Javadoc for methods with varargs use `...`, but the signatures generated by API Diff use `[]`, so API Diff cannot find the appropriate javadoc in the HTML for vararg methods, which leads to a failure to show the differences in the javadoc for such methods.

There are multiple possible ways to fix that, but the proposal herein is to try to normalize the keys to use `[]` while reading the HTML.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904080](https://bugs.openjdk.org/browse/CODETOOLS-7904080): APIDiff does not detect javadoc (and changes to javadoc) for methods with varargs (**Bug** - P3)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/apidiff.git pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/31.diff">https://git.openjdk.org/apidiff/pull/31.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/31#issuecomment-3313201903)
</details>
