### PR TITLE
7904082: The UI for API Diff could be improved

### DIFF
--- a/src/share/classes/jdk/codetools/apidiff/Options.java
+++ b/src/share/classes/jdk/codetools/apidiff/Options.java
@@ -171,6 +171,7 @@ public class Options {
     Boolean compareDocComments;
     Boolean compareApiDescriptions;
     Boolean compareApiDescriptionsAsText;
+    Boolean showUnchanged;
     String jdkDocs;
 
     // output options
@@ -181,7 +182,6 @@ public class Options {
     Path mainStylesheet;
     List<Path> extraStylesheets;
     List<Path> resourceFiles;
-    boolean showEqual;
 
     /**
      * The position of additional text to be included in the report.
@@ -333,6 +333,16 @@ public class Options {
             @Override
             void process(String opt, String arg, Options options) throws BadOption {
                 options.compareDocComments = asBoolean(arg);
+            }
+        },
+
+        /**
+         * {@code --show-unchanged} <var>boolean-value</var>
+         */
+        SHOW_UNCHANGED("--show-unchanged", "opt.arg.boolean") {
+            @Override
+            void process(String opt, String arg, Options options) throws BadOption {
+                options.showUnchanged = asBoolean(arg);
             }
         },
 
@@ -910,6 +920,15 @@ public class Options {
     }
 
     /**
+     * Returns whether unchanged API elements should be unconditionally shown.
+     *
+     * @return {@code true} if unchanged API elements should be unconditionally shown
+     */
+    public boolean showUnchanged() {
+        return showUnchanged;
+    }
+
+    /**
      * Returns whether documentation comments should be compared.
      *
      * @return {@code true} if documentation comments should be compared
@@ -979,10 +998,6 @@ public class Options {
      */
     public List<Path> getResourceFiles() {
         return (resourceFiles == null) ? Collections.emptyList() : resourceFiles;
-    }
-
-    public boolean showEqual() {
-        return showEqual;
     }
 
     /**
@@ -1080,6 +1095,10 @@ public class Options {
         if (compareDocComments == null) {
             // if not specified explicitly, compare doc comments if not comparing API descriptions
             compareDocComments = !compareApiDescriptions;
+        }
+
+        if (showUnchanged == null) {
+            showUnchanged = false;
         }
 
         if (resourceFiles != null) {

--- a/src/share/classes/jdk/codetools/apidiff/report/html/ModulePageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/ModulePageReporter.java
@@ -181,10 +181,15 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
             }
         }
 
-        List<ContentAndResultKind> converted = dMaps.entrySet().stream().map(e -> f.apply(e.getKey(), e.getValue())).toList();
+        List<ContentAndResultKind> converted =
+                dMaps.entrySet()
+                     .stream()
+                     .map(e -> f.apply(e.getKey(), e.getValue()))
+                     .toList();
 
         if (!converted.isEmpty()) {
-            boolean allUnchanged = converted.stream().allMatch(c -> c.resultKind() == ResultKind.SAME);
+            boolean allUnchanged = converted.stream()
+                                            .allMatch(c -> c.resultKind() == ResultKind.SAME);
             HtmlTree section = HtmlTree.SECTION().setClass("enclosed");
             section.add(HtmlTree.H2(Text.of(msgs.getString(headingKey))));
             HtmlTree ul = HtmlTree.UL();
@@ -279,7 +284,7 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
         //       but arguably a better way would be to move code for the check or cross into
         //       the enclosing loop that builds the list.
 
-        ResultKind result = getResultGlyph(rPos);
+        ResultKind result = getResultKind(rPos);
 
         return new ContentAndResultKind(HtmlTree.SPAN(result.getContent(), Text.SPACE)
                 .add(HtmlTree.SPAN(contents).setClass("signature")), result);
@@ -355,7 +360,7 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
         // TODO: for now, this is stylistically similar to buildEnclosedElement,
         //       but arguably a better way would be to move code for the check or cross into
         //       the enclosing loop that builds the list.
-        ResultKind result = getResultGlyph(rPos);
+        ResultKind result = getResultKind(rPos);
 
         return new ContentAndResultKind(HtmlTree.SPAN(result.getContent(), Text.SPACE)
                 .add(HtmlTree.SPAN(contents).setClass("signature")), result);

--- a/src/share/classes/jdk/codetools/apidiff/report/html/ModulePageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/ModulePageReporter.java
@@ -193,8 +193,8 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
                 if (!allUnchanged && c.resultKind() == ResultKind.SAME) {
                     item.setClass("unchanged");
                 }
+                ul.add(item);
             }
-            converted.forEach(c -> ul.add());
             section.add(ul);
             if (allUnchanged) {
                 section = HtmlTree.DIV(section).setClass("unchanged");

--- a/src/share/classes/jdk/codetools/apidiff/report/html/ModulePageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/ModulePageReporter.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -163,7 +164,7 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
     private <T> void addDirectives(List<Content> contents,
                                String headingKey,
                                Predicate<RelativePosition<?>> filter,
-                               BiFunction<RelativePosition<?>, APIMap<T>, Content> f) {
+                               BiFunction<RelativePosition<?>, APIMap<T>, Optional<Content>> f) {
         Map<RelativePosition<?>, APIMap<T>> dMaps = new TreeMap<>(RelativePosition.elementKeyIndexComparator);
         // apiMaps will only contain maps for directives which should be compared and displayed;
         // i.e. they have already been filtered according to accessKind.allDirectiveDetails
@@ -179,27 +180,29 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
             }
         }
 
-        if (!dMaps.isEmpty()) {
+        List<Content> elements = dMaps.entrySet().stream().map(e -> f.apply(e.getKey(), e.getValue())).filter(c -> c.isPresent()).map(opt -> opt.orElseThrow()).toList();
+
+        if (!elements.isEmpty()) {
             HtmlTree section = HtmlTree.SECTION().setClass("enclosed");
             section.add(HtmlTree.H2(Text.of(msgs.getString(headingKey))));
             HtmlTree ul = HtmlTree.UL();
-            dMaps.forEach((rp, apiMap) -> ul.add(HtmlTree.LI(f.apply(rp, apiMap))));
+            elements.forEach(el -> ul.add(HtmlTree.LI(el)));
             section.add(ul);
             contents.add(section);
         }
     }
 
-    private Content buildExports(RelativePosition<?> rPos, APIMap<ExportsDirective> apiMap) {
+    private Optional<Content> buildExports(RelativePosition<?> rPos, APIMap<ExportsDirective> apiMap) {
         return buildExportsOpensProvides(rPos, apiMap, Keywords.EXPORTS, Keywords.TO,
                 ExportsDirective::getPackage, ExportsDirective::getTargetModules);
     }
 
-    private Content buildOpens(RelativePosition<?> rPos, APIMap<OpensDirective> apiMap) {
+    private Optional<Content> buildOpens(RelativePosition<?> rPos, APIMap<OpensDirective> apiMap) {
         return buildExportsOpensProvides(rPos, apiMap, Keywords.OPENS, Keywords.TO,
                 OpensDirective::getPackage, OpensDirective::getTargetModules);
     }
 
-    private Content buildProvides(RelativePosition<?> rPos, APIMap<ProvidesDirective> apiMap) {
+    private Optional<Content> buildProvides(RelativePosition<?> rPos, APIMap<ProvidesDirective> apiMap) {
         // ProvidesDirective is unusual in that part of it (i.e. the implementations)
         // is not part of the public API, and should only be displayed if allDirectiveDetails
         // is true.
@@ -208,13 +211,13 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
                 pd -> allDirectiveDetails ? pd.getImplementations() : Collections.emptyList());
     }
 
-    private Content buildUses(RelativePosition<?> rPos, APIMap<UsesDirective> apiMap) {
+    private Optional<Content> buildUses(RelativePosition<?> rPos, APIMap<UsesDirective> apiMap) {
         return buildExportsOpensProvides(rPos, apiMap, Keywords.USES, Content.empty,
                 UsesDirective::getService, d -> Collections.emptyList());
     }
 
     private <T extends Directive, U extends Element, V extends Element>
-    Content buildExportsOpensProvides(RelativePosition<?> rPos, APIMap<T> apiMap,
+    Optional<Content> buildExportsOpensProvides(RelativePosition<?> rPos, APIMap<T> apiMap,
                                       Content directiveKeyword, Content sublistKeyword,
                                       Function<T, U> getPrimaryElement,
                                       Function<T, List<V>> getSecondaryElements) {
@@ -261,12 +264,17 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
             }
         }
 
+        ResultKind result = getResultGlyph(rPos);
+
+        if (result == ResultKind.SAME) {
+            return Optional.empty();
+        }
 
         // TODO: for now, this is stylistically similar to buildEnclosedElement,
         //       but arguably a better way would be to move code for the check or cross into
         //       the enclosing loop that builds the list.
-        return HtmlTree.SPAN(getResultGlyph(rPos), Text.SPACE)
-                .add(HtmlTree.SPAN(contents).setClass("signature"));
+        return Optional.of(HtmlTree.SPAN(result.getContent(), Text.SPACE)
+                .add(HtmlTree.SPAN(contents).setClass("signature")));
 
     }
 
@@ -288,7 +296,7 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
         }
     }
 
-    private Content buildRequires(RelativePosition<?> rPos, APIMap<RequiresDirective> apiMap) {
+    private Optional<Content> buildRequires(RelativePosition<?> rPos, APIMap<RequiresDirective> apiMap) {
         List<Content> contents = new ArrayList<>();
 
         contents.add(Keywords.REQUIRES);
@@ -337,11 +345,16 @@ class ModulePageReporter extends PageReporter<ModuleElementKey> {
         // TODO: would be nice to link to the module page if it can be determined to be available.
         contents.add(Text.of(archetype.getDependency().getQualifiedName()));
 
+        ResultKind result = getResultGlyph(rPos);
+
+        if (result == ResultKind.SAME) {
+            return Optional.empty();
+        }
 
         // TODO: for now, this is stylistically similar to buildEnclosedElement,
         //       but arguably a better way would be to move code for the check or cross into
         //       the enclosing loop that builds the list.
-        return HtmlTree.SPAN(getResultGlyph(rPos), Text.SPACE)
-                .add(HtmlTree.SPAN(contents).setClass("signature"));
+        return Optional.of(HtmlTree.SPAN(result.getContent(), Text.SPACE)
+                .add(HtmlTree.SPAN(contents).setClass("signature")));
     }
 }

--- a/src/share/classes/jdk/codetools/apidiff/report/html/PageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/PageReporter.java
@@ -1596,13 +1596,13 @@ abstract class PageReporter<K extends ElementKey> implements Reporter {
          * Used in a 2-way comparison when it is determined that an element has been added.
          */
         // possible alternatives: '>' (for example, as used in text diff tools) or other right-pointing arrows
-        ADDED(HtmlTree.SPAN(Entity.PLUS).setClass("partial")),
+        ADDED(HtmlTree.SPAN(Entity.PLUS).setClass("add")),
 
         /**
          * Used in a 2-way comparison when it is determined that an element has been removed.
          */
         // possible alternatives: '<' (for example, as used in text diff tools) or other left-pointing arrows
-        REMOVED(HtmlTree.SPAN(Entity.MINUS).setClass("partial")),
+        REMOVED(HtmlTree.SPAN(Entity.MINUS).setClass("remove")),
         ;
 
         private final Content content;

--- a/src/share/classes/jdk/codetools/apidiff/report/html/PageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/PageReporter.java
@@ -511,32 +511,37 @@ abstract class PageReporter<K extends ElementKey> implements Reporter {
         if (infoText == null) {
             infoText = String.join(" : ", parent.options.getAllAPIOptions().keySet());
         }
-        String showUnchangedCheckbox =
-                """
-                <script>
-                    function adjustShowUnchanged() {
-                        if (document.getElementById("show-unchanged-checkbox").checked) {
-                            var unchanged = document.getElementsByClassName("unchanged");
-                            for (var i = 0; i < unchanged.length; i++) {
-                                unchanged[i].classList.remove("hidden");
-                            }
-                        } else {
-                            var unchanged = document.getElementsByClassName("unchanged");
-                            for (var i = 0; i < unchanged.length; i++) {
-                                unchanged[i].classList.add("hidden");
+        List<Content> infoBox = new ArrayList<>();
+        infoBox.add(new RawHtml(infoText));
+        if (kind == InfoTextKind.HEADER) {
+            String showUnchangedCheckbox =
+                    """
+                    <script>
+                        function adjustShowUnchanged() {
+                            if (document.getElementById("show-unchanged-checkbox").checked) {
+                                var unchanged = document.getElementsByClassName("unchanged");
+                                for (var i = 0; i < unchanged.length; i++) {
+                                    unchanged[i].classList.remove("hidden");
+                                }
+                            } else {
+                                var unchanged = document.getElementsByClassName("unchanged");
+                                for (var i = 0; i < unchanged.length; i++) {
+                                    unchanged[i].classList.add("hidden");
+                                }
                             }
                         }
-                    }
-                    document.addEventListener("DOMContentLoaded", function() {
-                      adjustShowUnchanged();
-                    });
-                </script>
-                <input type='checkbox' id='show-unchanged-checkbox'
-                       onchange='adjustShowUnchanged()'>
-                Show unchanged
-                </input>"
-                """;
-        contents.add(HtmlTree.DIV(new RawHtml(infoText), new RawHtml(showUnchangedCheckbox)).setClass("info"));
+                        document.addEventListener("DOMContentLoaded", function() {
+                            adjustShowUnchanged();
+                        });
+                    </script>
+                    <input type='checkbox' id='show-unchanged-checkbox'
+                           onchange='adjustShowUnchanged()'>
+                    Show unchanged
+                    </input>
+                    """;
+            infoBox.add(new RawHtml(showUnchangedCheckbox));
+        }
+        contents.add(HtmlTree.DIV(infoBox.toArray(Content[]::new)).setClass("info"));
         Text index = Text.of(parent.indexPageReporter.getName());
         HtmlTree ul = HtmlTree.UL();
         ul.add(HtmlTree.LI((pageKey == null) ? index : HtmlTree.A(links.getPath("index.html").getPath(), index)));

--- a/src/share/classes/jdk/codetools/apidiff/report/html/PageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/PageReporter.java
@@ -513,7 +513,7 @@ abstract class PageReporter<K extends ElementKey> implements Reporter {
         }
         List<Content> infoBox = new ArrayList<>();
         infoBox.add(new RawHtml(infoText));
-        if (kind == InfoTextKind.HEADER) {
+        if (kind == InfoTextKind.HEADER && !parent.options.showUnchanged()) {
             String showUnchangedCheckbox =
                     """
                     <script>

--- a/src/share/classes/jdk/codetools/apidiff/report/html/PageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/PageReporter.java
@@ -840,6 +840,7 @@ abstract class PageReporter<K extends ElementKey> implements Reporter {
      */
     protected Content buildMissingInfo(Position pos) {
         if (missing.containsKey(pos)) {
+            ResultKind result = getResultGlyph(pos);
             // TODO: use an L10N-friendly builder, or use an API list builder, building Content?
             String onlyIn = apiMaps.get(pos).keySet().stream()
                     .map(a -> a.name)
@@ -852,7 +853,7 @@ abstract class PageReporter<K extends ElementKey> implements Reporter {
                     .map(a -> a.name)
                     .collect(Collectors.joining(", "));
             String info = msgs.getString("element.onlyInMissingIn", onlyIn, missingIn);
-            return HtmlTree.SPAN(Text.of(info)).setClass("missing");
+            return HtmlTree.SPAN(Text.of(info)).setClass(result.getCaptionClass() != null ? "missing " + result.getCaptionClass() : "missing");
         } else {
             return Content.empty;
         }
@@ -1570,7 +1571,7 @@ abstract class PageReporter<K extends ElementKey> implements Reporter {
 
     }
     public enum ResultKind {
-        UNKNOWN(Text.of("?")),
+        UNKNOWN(Text.of("?"), null),
         // The following names are intended to be "semantic" or "abstract" names,
         // distinct from the concrete representations used in the generated documentation.
         // The names are intentionally different from any corresponding entity names.
@@ -1578,43 +1579,47 @@ abstract class PageReporter<K extends ElementKey> implements Reporter {
          * Used when two elements compare as equal.
          */
         // possible alternatives: Entity.CHECK
-        SAME(HtmlTree.SPAN(Entity.EQUALS).setClass("same")),
+        SAME(HtmlTree.SPAN(Entity.EQUALS).setClass("same"), null),
 
         /**
          * Used when two elements compare as not equal.
          */
         // possible alternatives: Entity.CROSS
-        DIFFERENT(HtmlTree.SPAN(Entity.NE).setClass("diff")),
+        DIFFERENT(HtmlTree.SPAN(Entity.NE).setClass("diff"), null),
 
         /**
          * Used when an element does not appear in all instances of the APIs being compared.
          * See also {@link #ADDED}, {@link #REMOVED}.
          */
-        PARTIAL(HtmlTree.SPAN(Entity.CIRCLED_DIGIT_ONE).setClass("partial")),
+        PARTIAL(HtmlTree.SPAN(Entity.CIRCLED_DIGIT_ONE).setClass("partial"), null),
 
         /**
          * Used in a 2-way comparison when it is determined that an element has been added.
          */
         // possible alternatives: '>' (for example, as used in text diff tools) or other right-pointing arrows
-        ADDED(HtmlTree.SPAN(Entity.PLUS).setClass("add")),
+        ADDED(HtmlTree.SPAN(Entity.PLUS).setClass("add"), "missing-add"),
 
         /**
          * Used in a 2-way comparison when it is determined that an element has been removed.
          */
         // possible alternatives: '<' (for example, as used in text diff tools) or other left-pointing arrows
-        REMOVED(HtmlTree.SPAN(Entity.MINUS).setClass("remove")),
+        REMOVED(HtmlTree.SPAN(Entity.MINUS).setClass("remove"), "missing-remove"),
         ;
 
         private final Content content;
+        private final String captionClass;
 
-        private ResultKind(Content content) {
+        private ResultKind(Content content, String captionClass) {
             this.content = content;
+            this.captionClass = captionClass;
         }
 
         public Content getContent() {
             return content;
         }
 
-
+        public String getCaptionClass() {
+            return captionClass;
+        }
     }
 }

--- a/src/share/classes/jdk/codetools/apidiff/report/html/TypePageReporter.java
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/TypePageReporter.java
@@ -554,7 +554,7 @@ class TypePageReporter extends PageReporter<TypeElementKey> {
         }
 
         ContentAndResultKind build() {
-            ResultKind result = getResultGlyph(ePos);
+            ResultKind result = getResultKind(ePos);
 
             Content eq = result.getContent();
 
@@ -756,7 +756,7 @@ class TypePageReporter extends PageReporter<TypeElementKey> {
         }
 
         private ContentAndResultKind build() {
-            ResultKind result = getResultGlyph(vPos);
+            ResultKind result = getResultKind(vPos);
             Content eq = result.getContent();
 
             APIMap<? extends Element> vMap = getElementMap(vKey);
@@ -990,7 +990,7 @@ class TypePageReporter extends PageReporter<TypeElementKey> {
             }
 
             HtmlTree section = HtmlTree.SECTION(HtmlTree.H2(Text.of(msgs.getString("serial.serialized-form")))).setClass("serial-form");
-            section.add(getResultGlyph(sfPos).getContent()).add(buildMissingInfo(sfPos));
+            section.add(getResultKind(sfPos).getContent()).add(buildMissingInfo(sfPos));
             addSerialVersionUID(section);
             addSerializedFields(section);
             addSerializationMethods(section);
@@ -1004,7 +1004,7 @@ class TypePageReporter extends PageReporter<TypeElementKey> {
             // TODO: weave in the text from serialized-form.html
 
             section.add(HtmlTree.H3(Text.of("serialVersionUID")));
-            section.add(getResultGlyph(uPos).getContent());
+            section.add(getResultKind(uPos).getContent());
             if (differentValues.containsKey(uPos)) {
                 APIMap<Content> alternatives = APIMap.of();
                 values.forEach((api, v) -> alternatives.put(api, Text.of(String.valueOf(v))));
@@ -1061,7 +1061,7 @@ class TypePageReporter extends PageReporter<TypeElementKey> {
         private Content buildSerializedField(RelativePosition<String> fPos) {
             @SuppressWarnings("unchecked")
             APIMap<SerializedForm.Field> fMap = (APIMap<SerializedForm.Field>) apiMaps.get(fPos);
-            Content glyph = getResultGlyph(fPos).getContent();
+            Content glyph = getResultKind(fPos).getContent();
 
             Content type;
             APIMap<? extends TypeMirror> types;

--- a/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
@@ -214,12 +214,14 @@ div.signature {
     color: #008;
 }
 
-.doc-files span.missing-add, .element span.missing-add, .enclosed span.missing-add, .serial-form span.missing-add {
+.doc-files span.missing-caption-add, .element span.missing-caption-add,
+.enclosed span.missing-caption-add, .serial-form span.missing-caption-add {
     background: #dfd;
     color: #008;
 }
 
-.doc-files span.missing-remove, .element span.missing-remove, .enclosed span.missing-remove, .serial-form span.missing-remove {
+.doc-files span.missing-caption-remove, .element span.missing-caption-remove,
+.enclosed span.missing-caption-remove, .serial-form span.missing-caption-remove {
     background: #fdd;
     color: #008;
 }

--- a/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
@@ -179,7 +179,9 @@ div.signature {
 
 .doc-files span.diff,   .element span.diff,   .enclosed span.diff,   .serial-form span.diff,
 .doc-files span.same,   .element span.same,   .enclosed span.same,   .serial-form span.same,
-.doc-files span.partial, .element span.partial, .enclosed span.partial, .serial-form span.partial {
+.doc-files span.partial, .element span.partial, .enclosed span.partial, .serial-form span.partial,
+.doc-files span.add, .element span.add, .enclosed span.add, .serial-form span.add,
+.doc-files span.remove, .element span.remove, .enclosed span.remove, .serial-form span.remove {
     display: inline-block;
     width: 2em;
     margin-right: 0.5ex;
@@ -188,17 +190,27 @@ div.signature {
 }
 
 .doc-files span.diff, .element span.diff, .enclosed span.diff, .serial-form span.diff {
-    background: #fdd;
+    background: #ddf;
     color: #800;
 }
 
 .doc-files span.same, .element span.same, .enclosed span.same, .serial-form span.same {
-    background: #dfd;
+    background: #ddd;
     color: #080;
 }
 
 .doc-files span.partial, .element span.partial, .enclosed span.partial, .serial-form span.partial {
     background: #ddf;
+    color: #008;
+}
+
+.doc-files span.add, .element span.add, .enclosed span.add, .serial-form span.add {
+    background: #dfd;
+    color: #008;
+}
+
+.doc-files span.remove, .element span.remove, .enclosed span.remove, .serial-form span.remove {
+    background: #fdd;
     color: #008;
 }
 

--- a/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
@@ -495,4 +495,9 @@ table.summary tfoot th {
      border-top: 1px solid lightgrey;
  }
 
+ .unchanged {
+ }
 
+ .hidden {
+     display: none;
+ }

--- a/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
@@ -214,6 +214,16 @@ div.signature {
     color: #008;
 }
 
+.doc-files span.missing-add, .element span.missing-add, .enclosed span.missing-add, .serial-form span.missing-add {
+    background: #dfd;
+    color: #008;
+}
+
+.doc-files span.missing-remove, .element span.missing-remove, .enclosed span.missing-remove, .serial-form span.missing-remove {
+    background: #fdd;
+    color: #008;
+}
+
 .doc-files span.missing, .element span.missing, .enclosed span.missing, .serial-form span.missing,
 .element span.notes {
     margin-right: 10px;

--- a/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/resources/apidiff.css
@@ -190,40 +190,40 @@ div.signature {
 }
 
 .doc-files span.diff, .element span.diff, .enclosed span.diff, .serial-form span.diff {
-    background: #ddf;
-    color: #800;
+    background: #e0e0e0;
+    color: #000;
 }
 
 .doc-files span.same, .element span.same, .enclosed span.same, .serial-form span.same {
-    background: #ddd;
-    color: #080;
+    background: #ffffff;
+    color: #000;
 }
 
 .doc-files span.partial, .element span.partial, .enclosed span.partial, .serial-form span.partial {
     background: #ddf;
-    color: #008;
+    color: #000;
 }
 
 .doc-files span.add, .element span.add, .enclosed span.add, .serial-form span.add {
-    background: #dfd;
-    color: #008;
+    background: #cfc;
+    color: #000;
 }
 
 .doc-files span.remove, .element span.remove, .enclosed span.remove, .serial-form span.remove {
-    background: #fdd;
-    color: #008;
+    background: #fcc;
+    color: #000;
 }
 
 .doc-files span.missing-caption-add, .element span.missing-caption-add,
 .enclosed span.missing-caption-add, .serial-form span.missing-caption-add {
-    background: #dfd;
-    color: #008;
+    background: #cfc;
+    color: #000;
 }
 
 .doc-files span.missing-caption-remove, .element span.missing-caption-remove,
 .enclosed span.missing-caption-remove, .serial-form span.missing-caption-remove {
-    background: #fdd;
-    color: #008;
+    background: #fcc;
+    color: #000;
 }
 
 .doc-files span.missing, .element span.missing, .enclosed span.missing, .serial-form span.missing,

--- a/src/share/classes/jdk/codetools/apidiff/report/html/resources/report.properties
+++ b/src/share/classes/jdk/codetools/apidiff/report/html/resources/report.properties
@@ -123,7 +123,7 @@ htmldiffs.not-in-only-in=\
   Not in {0}; only in {1}
 
 htmldiffs.only-in-not-in=\
-  Only in {0}; not i {1}
+  Only in {0}; not in {1}
 
 notes.heading=\
   Notes

--- a/src/share/classes/jdk/codetools/apidiff/resources/help.properties
+++ b/src/share/classes/jdk/codetools/apidiff/resources/help.properties
@@ -127,6 +127,9 @@ opt.desc.release=\
 opt.desc.resource-files=\
     Specifies resource files to be copied from an API directory
 
+opt.desc.show-unchanged=\
+    Unchanged elements should be unconditionally shown in the resulting diff
+
 opt.desc.source=\
     Specifies the version of the platform for an API.
 

--- a/src/share/doc/apidiff.md
+++ b/src/share/doc/apidiff.md
@@ -287,6 +287,11 @@ to repeat these options for each API to be compared.
     <p class="note">This option may be useful when comparing HTML documentation that
     depend on some non-HTML resource files.</p>
 
+<a id="option-show-unchanged">`--show-unchanged` *boolean*</a>
+:   If true, unchanged elements will be show unconditionally. When false or
+    missing, the user viewing the diff will have an option to show or hide the
+    unchanged elements.
+
 ### Other Options
 
 <a id="option-help">`--help`, `-help`, `-h`, `-?`</a>

--- a/test/junit/apitest/UnchangedTest.java
+++ b/test/junit/apitest/UnchangedTest.java
@@ -397,7 +397,7 @@ public class UnchangedTest extends APITester {
             @Override
             public Object visitStartElement(StartElementTree node, Object p) {
                 String name = node.getName().toString();
-                
+
                 if (ELEMENTS_WITH_UNCHANGED_CLASS.contains(name)) {
                     nestedElements.push(new ElementDesc(name, unchanged));
 
@@ -414,7 +414,7 @@ public class UnchangedTest extends APITester {
             @Override
             public Object visitEndElement(EndElementTree node, Object p) {
                 String name = node.getName().toString();
-                
+
                 if (ELEMENTS_WITH_UNCHANGED_CLASS.contains(name)) {
                     ElementDesc removed = nestedElements.pop();
 
@@ -443,7 +443,7 @@ public class UnchangedTest extends APITester {
                 }
                 return null;
             }
-            
+
             record ElementDesc(String name, boolean previousUnchanged) {}
         }.scan(html, null);
 
@@ -504,7 +504,7 @@ public class UnchangedTest extends APITester {
             public boolean delete() {
                 throw new UnsupportedOperationException();
             }
-            
+
         });
         return html;
     }

--- a/test/junit/apitest/UnchangedTest.java
+++ b/test/junit/apitest/UnchangedTest.java
@@ -1,0 +1,511 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package apitest;
+
+import apitest.lib.APITester;
+import com.sun.source.doctree.DocCommentTree;
+import com.sun.source.doctree.DocTree;
+import com.sun.source.doctree.EndElementTree;
+import com.sun.source.doctree.StartElementTree;
+import com.sun.source.doctree.TextTree;
+import com.sun.source.util.DocTreeScanner;
+import com.sun.source.util.DocTrees;
+import com.sun.source.util.JavacTask;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.Stack;
+import javax.tools.FileObject;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import toolbox.ModuleBuilder;
+
+/**
+ * Tests the output for unchanged elements.
+ */
+public class UnchangedTest extends APITester {
+
+    @Test
+    public void testAllUnchanged() throws IOException {
+        Path base = getScratchDir();
+        log.println(base);
+
+        List<String> options = new ArrayList<>();
+
+        Path originalDir = base.resolve("original").resolve("src");
+        Path updatedDir = base.resolve("updated").resolve("src");
+
+        for (Path target : new Path[] {originalDir, updatedDir}) {
+            ModuleBuilder m =
+                    new ModuleBuilder(tb, "m")
+                            .exports("p").exports("p2")
+                            .opens("p").opens("p2")
+                            .provides("java.lang.Runnable", "p.C1", "p.C2")
+                            .provides("java.lang.FunctionalInterface", "p2.C")
+                            .uses("java.lang.Runnable")
+                            .uses("java.lang.FunctionalInterface")
+                            .requiresTransitive("java.compiler")
+                            .requiresTransitive("jdk.compiler");
+
+            m.classes("""
+                       package p;
+                       /** class documentation */
+                       public class C1 implements Runnable {
+                           /** test field documentation1 */
+                           public final int F1;
+                           /** test field documentation2 */
+                           public final int F2;
+                           /** test constructor documentation1 */
+                           public C1() {}
+                           /** test constructor documentation2 */
+                           public C1(int i) {}
+                           /** test method documentation */
+                           public void test() { }
+                           /** run method documentation */
+                           public void run() { }
+                       }
+                       """);
+
+            m.classes("""
+                       package p;
+                       /** class documentation */
+                       public class C2 implements Runnable {
+                           /** test method documentation */
+                           public void test() { }
+                           /** run method documentation */
+                           public void run() { }
+                       }
+                       """);
+
+            m.classes("""
+                       package p2;
+                       /** class documentation */
+                       public class C implements FunctionalInterface {
+                           /** test method documentation */
+                           public void test() { }
+                           /** run method documentation */
+                           public void run() { }
+                       }
+                       """);
+
+            m.write(target);
+
+            new ModuleBuilder(tb, "m2").write(target);
+
+            options.addAll(List.of(
+                    "--api", target.getParent().getFileName().toString(),
+                    "--module-source-path", target.toString()));
+        }
+
+        options.addAll(List.of(
+                "--include", "m/**",
+                "--include", "m2/**",
+                "-d", base.resolve("out").toString(),
+                "--verbose", "missing"));
+
+        log.println("Options: " + options);
+
+        run(options);
+
+        {
+            List<String> unchangedTexts =
+                    gatherUnchangedTexts(base, "out/index.html");
+            List<String> expectedUnchangedTextsModule =
+                    List.of("""
+                            Modules
+                             m m2
+                            """);
+            Assertions.assertEquals(expectedUnchangedTextsModule, unchangedTexts);
+        }
+
+        {
+            List<String> unchangedTexts =
+                    gatherUnchangedTexts(base, "out/m/module-summary.html");
+            List<String> expectedUnchangedTextsModule =
+                    List.of("""
+                            Exports
+                             exports p exports p2
+                            """,
+                            """
+                            Opens
+                             opens p opens p2
+                            """,
+                            """
+                            Requires
+                             requires transitive java.compiler requires transitive jdk.compiler
+                            """,
+                            """
+                            Packages
+                             p p2
+                            """);
+            Assertions.assertEquals(expectedUnchangedTextsModule, unchangedTexts);
+        }
+
+        {
+            List<String> unchangedTexts =
+                    gatherUnchangedTexts(base, "out/m/p/package-summary.html");
+            List<String> expectedUnchangedTextsModule =
+                    List.of("""
+                            Types
+                             C1 C2
+                            """);
+            Assertions.assertEquals(expectedUnchangedTextsModule, unchangedTexts);
+        }
+
+        {
+            List<String> unchangedTexts =
+                    gatherUnchangedTexts(base, "out/m/p/C1.html");
+            List<String> expectedUnchangedTextsModule =
+                    List.of("""
+                            Fields
+                            public final int F1
+                            public final int F2
+                            """,
+                            """
+                            Constructors
+                            public C1()
+                            public C1(int i)
+                            """,
+                            """
+                            Methods
+                            public void run()
+                            public void test()
+                            """);
+            Assertions.assertEquals(expectedUnchangedTextsModule, unchangedTexts);
+        }
+    }
+
+    @Test
+    public void testSomeUnchanged() throws IOException {
+        //one method in C1 with a changed javadoc, and module info changed:
+        Path base = getScratchDir();
+        log.println(base);
+
+        List<String> options = new ArrayList<>();
+
+        Path originalDir = base.resolve("original").resolve("src");
+        Path updatedDir = base.resolve("updated").resolve("src");
+
+        for (Path target : new Path[] {originalDir, updatedDir}) {
+            ModuleBuilder m;
+            if (target == originalDir) {
+                m =
+                    new ModuleBuilder(tb, "m")
+                            .exports("p").exports("p2").exports("p3")
+                            .opens("p").opens("p2").opens("p3")
+                            .provides("java.lang.Runnable", "p.C1", "p.C2")
+                            .provides("java.lang.FunctionalInterface", "p2.C")
+                            .uses("java.lang.Runnable")
+                            .uses("java.lang.FunctionalInterface")
+                            .requiresTransitive("java.compiler")
+                            .requiresTransitive("jdk.compiler");
+            } else {
+                m =
+                    new ModuleBuilder(tb, "m")
+                            .exports("p").exports("p3").exports("p4")
+                            .opens("p").opens("p3").opens("p4")
+                            .provides("java.lang.Runnable", "p.C1", "p4.C")
+                            .provides("java.lang.FunctionalInterface", "p2.C")
+                            .provides("java.io.Serializable", "p4.C")
+                            .uses("java.io.Serializable")
+                            .uses("java.lang.FunctionalInterface")
+                            .requiresTransitive("java.compiler")
+                            .requiresTransitive("java.desktop");
+            }
+
+            if (target == originalDir) {
+                m.classes("""
+                           package p;
+                           /** class documentation */
+                           public class C1 implements Runnable {
+                               /** test field documentation1 */
+                               public final int F1;
+                               /** test field documentation2 */
+                               public final int F2;
+                               /** test constructor documentation1 */
+                               public C1() {}
+                               /** test constructor documentation2 */
+                               public C1(int i) {}
+                               /** test method documentation */
+                               public void test() { }
+                               /** run method documentation */
+                               public void run() { }
+                           }
+                           """);
+            } else {
+                m.classes("""
+                           package p;
+                           /** class documentation */
+                           public class C1 implements Runnable {
+                               /** test field documentation1 - updated */
+                               public final int F1;
+                               /** test field documentation2 */
+                               public final int F2;
+                               /** test constructor documentation1 - updated */
+                               public C1() {}
+                               /** test constructor documentation2 */
+                               public C1(int i) {}
+                               /** test method documentation - updated */
+                               public void test() { }
+                               /** run method documentation */
+                               public void run() { }
+                           }
+                           """);
+            }
+
+            m.classes("""
+                       package p;
+                       /** class documentation */
+                       public class C2 implements Runnable {
+                           /** test method documentation */
+                           public void test() { }
+                           /** run method documentation */
+                           public void run() { }
+                       }
+                       """);
+
+            m.classes("""
+                       package p2;
+                       /** class documentation */
+                       public class C implements FunctionalInterface {
+                           /** test method documentation */
+                           public void test() { }
+                           /** run method documentation */
+                           public void run() { }
+                       }
+                       """);
+
+            m.classes("""
+                       package p3;
+                       /** class documentation */
+                       public class C {
+                       }
+                       """);
+
+            if (target == updatedDir) {
+                m.classes("""
+                           package p4;
+                           /** class documentation */
+                           public class C implements java.io.Serializable, Runnable {
+                               /** test method documentation */
+                               public void test() { }
+                               /** run method documentation */
+                               public void run() { }
+                           }
+                           """);
+            }
+
+            m.write(target);
+
+            new ModuleBuilder(tb, "m2").write(target);
+
+            options.addAll(List.of(
+                    "--api", target.getParent().getFileName().toString(),
+                    "--module-source-path", target.toString()));
+        }
+
+        options.addAll(List.of(
+                "--include", "m/**",
+                "--include", "m2/**",
+                "-d", base.resolve("out").toString(),
+                "--verbose", "missing"));
+
+        log.println("Options: " + options);
+
+        run(options);
+
+        {
+            List<String> unchangedTexts =
+                    gatherUnchangedTexts(base, "out/index.html");
+            List<String> expectedUnchangedTextsModule =
+                    List.of(" m2");
+            Assertions.assertEquals(expectedUnchangedTextsModule, unchangedTexts);
+        }
+
+        {
+            List<String> unchangedTexts =
+                    gatherUnchangedTexts(base, "out/m/module-summary.html");
+            List<String> expectedUnchangedTextsModule =
+                    List.of(" exports p", " exports p3",
+                            " opens p", " opens p3",
+                            " requires transitive java.compiler",
+                            " p3");
+            Assertions.assertEquals(expectedUnchangedTextsModule, unchangedTexts);
+        }
+
+        {
+            List<String> unchangedTexts =
+                    gatherUnchangedTexts(base, "out/m/p/package-summary.html");
+            List<String> expectedUnchangedTextsModule =
+                    List.of(" C2");
+            Assertions.assertEquals(expectedUnchangedTextsModule, unchangedTexts);
+        }
+
+        {
+            List<String> unchangedTexts =
+                    gatherUnchangedTexts(base, "out/m/p/C1.html");
+            List<String> expectedUnchangedTextsModule =
+                    List.of("public final int F2\n",
+                            "public C1(int i)\n",
+                            "public void run()\n");
+            Assertions.assertEquals(expectedUnchangedTextsModule, unchangedTexts);
+        }
+    }
+
+    private List<String> gatherUnchangedTexts(Path base, String path) throws IOException {
+        DocCommentTree html = parseHTML(base, path);
+        List<String> unchangedTexts = new ArrayList<>();
+
+        new DocTreeScanner<>() {
+            //HTML elements which may hold the unchanged class:
+            private static final Set<String> ELEMENTS_WITH_UNCHANGED_CLASS =
+                    Set.of("span", "div", "li");
+            private final Stack<ElementDesc> nestedElements = new Stack<>();
+            private boolean unchanged;
+            private final StringBuilder unchangedText = new StringBuilder();
+
+            @Override
+            public Object visitStartElement(StartElementTree node, Object p) {
+                String name = node.getName().toString();
+                
+                if (ELEMENTS_WITH_UNCHANGED_CLASS.contains(name)) {
+                    nestedElements.push(new ElementDesc(name, unchanged));
+
+                    for (DocTree t : node.getAttributes()) {
+                        String treeText = t.toString();
+                        if (treeText.contains("class=") && treeText.contains("unchanged")) {
+                            unchanged = true;
+                        }
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public Object visitEndElement(EndElementTree node, Object p) {
+                String name = node.getName().toString();
+                
+                if (ELEMENTS_WITH_UNCHANGED_CLASS.contains(name)) {
+                    ElementDesc removed = nestedElements.pop();
+
+                    if (!removed.name().equals(name)) {
+                        throw new IllegalStateException("Unexpected name!");
+                    }
+
+                    boolean wasUnchanged = unchanged;
+
+                    unchanged = removed.previousUnchanged();
+
+                    if (wasUnchanged && !unchanged) {
+                        String text = unchangedText.toString();
+
+                        unchangedTexts.add(text.replaceAll("\n+", "\n"));
+                        unchangedText.delete(0, unchangedText.length());
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public Object visitText(TextTree node, Object p) {
+                if (unchanged) {
+                    unchangedText.append(node.getBody());
+                }
+                return null;
+            }
+            
+            record ElementDesc(String name, boolean previousUnchanged) {}
+        }.scan(html, null);
+
+        return unchangedTexts;
+    }
+
+    private DocCommentTree parseHTML(Path base, String path) throws IOException {
+        String[] pathElements = path.split("/");
+        Path fileToTest = base;
+        for (String el : pathElements) {
+            fileToTest = fileToTest.resolve(el);
+        }
+        String content = Files.readString(fileToTest);
+        JavacTask task = (JavacTask) ToolProvider.getSystemJavaCompiler().getTask(null, null, null, null, null, null);
+        DocTrees trees = DocTrees.instance(task);
+        DocCommentTree html = trees.getDocCommentTree(new FileObject() {
+            @Override
+            public URI toUri() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String getName() {
+                return "test.html";
+            }
+
+            @Override
+            public InputStream openInputStream() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public OutputStream openOutputStream() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+                return content;
+            }
+
+            @Override
+            public Writer openWriter() throws IOException {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long getLastModified() {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean delete() {
+                throw new UnsupportedOperationException();
+            }
+            
+        });
+        return html;
+    }
+}


### PR DESCRIPTION
This PR intends to improve the result of API diff in a few ways:
- in the list of updated elements, using green for elements that were added (instead of elements that are unchanged), and red for removed elements. At least in cases two variants of an API are compared.
- making added/removed elements more prominent by also coloring the signature lines
- hiding unchanged elements by default.

An example diff that is produced before this patch:
https://cr.openjdk.org/~jlahoda/CODETOOLS-7904082/before/
after this patch:
https://cr.openjdk.org/~jlahoda/CODETOOLS-7904082/after/

Please let me know what you think. I'll see if I can reasonably add some tests for this functionality.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [CODETOOLS-7904082](https://bugs.openjdk.org/browse/CODETOOLS-7904082): The UI for API Diff could be improved (**Enhancement** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/apidiff.git pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.org/apidiff.git pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/apidiff/pull/32.diff">https://git.openjdk.org/apidiff/pull/32.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/apidiff/pull/32#issuecomment-3319842947)
</details>
